### PR TITLE
fix: recover debug-gather goroutine panics and free run state on stop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- fix: recover from panics in the background debug-gathering goroutine so a failure can no longer crash the whole extension, and remove the per-execution run state on stop to avoid an unbounded memory leak
+
 ## v1.0.23
 
 - build(deps): bump github.com/steadybit/extension-kit

--- a/extdebug/action.go
+++ b/extdebug/action.go
@@ -114,6 +114,15 @@ func (l *debugAction) Start(_ context.Context, state *DebugActionState) (*action
 	log.Info().Msg("Debug action **start**")
 
 	go func() {
+		// Recover so a panic while gathering debug information cannot crash the whole
+		// extension process (and take down other in-flight actions). Mark the run finished
+		// so Status completes instead of polling forever.
+		defer func() {
+			if r := recover(); r != nil {
+				log.Error().Msgf("Recovered from panic while gathering debug information: %v", r)
+				debugRuns.Store(state.ExecutionId, DebugRun{Finished: true})
+			}
+		}()
 		resultZip := RunSteadybitDebug(state.WorkingDir)
 		debugRuns.Store(state.ExecutionId, DebugRun{
 			Finished:  true,
@@ -163,6 +172,8 @@ func (l *debugAction) Status(_ context.Context, state *DebugActionState) (*actio
 
 func (l *debugAction) Stop(_ context.Context, state *DebugActionState) (*action_kit_api.StopResult, error) {
 	log.Info().Msg("Debug action **stop**")
+
+	debugRuns.Delete(state.ExecutionId)
 
 	err := os.RemoveAll(state.WorkingDir)
 	if err != nil {


### PR DESCRIPTION
Addresses the extension-debug audit MAJOR findings.

## 1. Unrecovered goroutine panic crashes the whole extension

`Start` spawns a detached goroutine running `RunSteadybitDebug(...)` with no panic recovery. A panic there is fatal to the **entire extension process**, taking down every other in-flight action it is serving.

**Fix:** recover in the goroutine, log the failure, and store `DebugRun{Finished: true}` so `Status` completes (instead of polling forever) — `Status` already handles a missing result zip gracefully (empty artifacts).

## 2. `debugRuns` map-entry leak

Entries are stored in `Prepare`/`Start` but never deleted, so the `sync.Map` grows by one entry per execution for the process lifetime.

**Fix:** `debugRuns.Delete(executionId)` in `Stop`.

## Testing
- `go build ./...`, `go vet`, `gofmt` clean.

## /simplify
3-agent pass (efficiency N/A for a recover+delete): all clean — no safe-go/recover helper exists to reuse (`exthttp.PanicRecovery` is HTTP-handler-only), the two `Store` paths are mutually exclusive, and both fixes are at the right altitude.

## Follow-up (deferred, single root cause)
`RunSteadybitDebug` takes no `context`, so two residuals remain and are best fixed together by making it cancellable + awaited in `Stop` before `os.RemoveAll`:
- if the gather goroutine finishes **after** `Stop`, its `debugRuns.Store` re-inserts an entry that won't be deleted (re-leak for the aborted/slow case);
- `Stop`'s `os.RemoveAll(WorkingDir)` can race the still-running goroutine writing into that dir.

Neither is a regression (the goroutine already wrote to `WorkingDir`); they need a cancellation redesign of `RunSteadybitDebug`. Happy to do that as a follow-up.