### PR TITLE
fix: don't remove the debug working dir while a gather is in flight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - fix: recover from panics in the background debug-gathering goroutine so a failure can no longer crash the whole extension, and remove the per-execution run state on stop to avoid an unbounded memory leak
+- fix: stop removing the debug working directory while it is still being gathered/archived, which could make steadybit-debug call `os.Exit(1)` and crash the whole extension when an experiment is stopped mid-run
 
 ## v1.0.23
 

--- a/extdebug/action.go
+++ b/extdebug/action.go
@@ -28,15 +28,35 @@ var (
 	_ action_kit_sdk.ActionWithStatus[DebugActionState] = (*debugAction)(nil) // Optional, needed when the action needs a status method
 	_ action_kit_sdk.ActionWithStop[DebugActionState]   = (*debugAction)(nil) // Optional, needed when the action needs a stop method
 
+	// debugRuns maps an execution id to its *debugRun.
 	debugRuns sync.Map
-	// debugCancels holds the cancel func for each running gather goroutine, keyed by
-	// execution id. Its presence also tells Stop whether a goroutine owns WorkingDir.
-	debugCancels sync.Map
 )
 
-type DebugRun struct {
-	Finished  bool
-	ResultZip string
+// debugRun is the single source of truth for one debug execution, guarded by mu. Keeping
+// the lifecycle flags together under one lock lets Start, Status, Stop and the gather
+// goroutine make the "is the gather still tarring WorkingDir?" decision atomically — which
+// determines who may remove WorkingDir without racing steadybit-debug's tar (a failed tar
+// makes it os.Exit(1) and crashes the whole extension).
+type debugRun struct {
+	mu         sync.Mutex
+	workingDir string
+	started    bool // the gather goroutine has been launched
+	gatherDone bool // RunSteadybitDebug has returned, so no tar is running anymore
+	stopped    bool // Stop has been called
+	cleaned    bool // workingDir has been removed (removal is idempotent)
+	finished   bool // the result is ready for Status
+	resultZip  string
+}
+
+// removeWorkingDir deletes the working directory at most once. The caller must hold mu.
+func (r *debugRun) removeWorkingDir() {
+	if r.cleaned {
+		return
+	}
+	r.cleaned = true
+	if err := os.RemoveAll(r.workingDir); err != nil {
+		log.Err(err).Msg("Failed to remove temp dir")
+	}
 }
 
 type DebugActionState struct {
@@ -106,9 +126,7 @@ func (l *debugAction) Prepare(_ context.Context, state *DebugActionState, reques
 		return nil, err
 	}
 	state.WorkingDir = temp
-	debugRuns.Store(state.ExecutionId, DebugRun{
-		Finished: false,
-	})
+	debugRuns.Store(state.ExecutionId, &debugRun{workingDir: temp})
 
 	return nil, nil
 }
@@ -116,8 +134,15 @@ func (l *debugAction) Prepare(_ context.Context, state *DebugActionState, reques
 func (l *debugAction) Start(_ context.Context, state *DebugActionState) (*action_kit_api.StartResult, error) {
 	log.Info().Msg("Debug action **start**")
 
-	ctx, cancel := context.WithCancel(context.Background())
-	debugCancels.Store(state.ExecutionId, cancel)
+	value, ok := debugRuns.Load(state.ExecutionId)
+	if !ok {
+		return nil, fmt.Errorf("state not found for execution id %s", state.ExecutionId)
+	}
+	run := value.(*debugRun)
+
+	run.mu.Lock()
+	run.started = true
+	run.mu.Unlock()
 
 	go func() {
 		// Recover so a panic while gathering debug information cannot crash the whole
@@ -126,24 +151,31 @@ func (l *debugAction) Start(_ context.Context, state *DebugActionState) (*action
 		defer func() {
 			if r := recover(); r != nil {
 				log.Error().Msgf("Recovered from panic while gathering debug information: %v", r)
-				debugRuns.Store(state.ExecutionId, DebugRun{Finished: true})
+				run.mu.Lock()
+				run.gatherDone = true
+				run.finished = true
+				if run.stopped {
+					run.removeWorkingDir()
+				}
+				run.mu.Unlock()
 			}
 		}()
 		resultZip := RunSteadybitDebug(state.WorkingDir)
 
-		// If the action was stopped while gathering, the result archive (which lives
-		// inside WorkingDir) is no longer wanted, and Stop deliberately left WorkingDir
-		// for this goroutine to remove: Stop can't, because removing WorkingDir while the
-		// tar above was still running would make steadybit-debug os.Exit(1) and crash the
-		// whole extension. Now that the tar is done, it is safe to remove here.
-		if ctx.Err() != nil {
-			_ = os.RemoveAll(state.WorkingDir)
-			return
+		run.mu.Lock()
+		run.gatherDone = true
+		if run.stopped {
+			// Stopped while gathering: the result archive (which lives inside WorkingDir)
+			// is no longer wanted, and Stop left WorkingDir for this goroutine to remove —
+			// Stop couldn't, because removing WorkingDir while the tar above was still
+			// running would make steadybit-debug os.Exit(1) and crash the whole extension.
+			// The tar has returned, so removing it here is now safe.
+			run.removeWorkingDir()
+		} else {
+			run.finished = true
+			run.resultZip = resultZip
 		}
-		debugRuns.Store(state.ExecutionId, DebugRun{
-			Finished:  true,
-			ResultZip: resultZip,
-		})
+		run.mu.Unlock()
 	}()
 
 	return &action_kit_api.StartResult{}, nil
@@ -156,29 +188,32 @@ func (l *debugAction) Status(_ context.Context, state *DebugActionState) (*actio
 	if !ok {
 		return nil, fmt.Errorf("state not found for execution id %s", state.ExecutionId)
 	}
-	if ok {
-		debugRun := value.(DebugRun)
-		if debugRun.Finished {
-			log.Info().Msg("Debug action **finished**")
-			artifacts := make([]action_kit_api.Artifact, 0)
-			_, err := os.Stat(debugRun.ResultZip)
+	run := value.(*debugRun)
+	run.mu.Lock()
+	finished := run.finished
+	resultZip := run.resultZip
+	run.mu.Unlock()
 
-			if err == nil { // file exists
-				content, err := extfile.File2Base64(debugRun.ResultZip)
-				if err != nil {
-					return nil, new(extension_kit.ToError("Failed to open content file", err))
-				}
-				artifacts = append(artifacts, action_kit_api.Artifact{
-					Label: "$(experimentKey)_$(executionId)_" + state.ExecutionId.String() + "_steadybit-debug.tar.gz",
-					Data:  content,
-				})
-				log.Info().Msg("Uploading debug result: " + debugRun.ResultZip)
+	if finished {
+		log.Info().Msg("Debug action **finished**")
+		artifacts := make([]action_kit_api.Artifact, 0)
+		_, err := os.Stat(resultZip)
+
+		if err == nil { // file exists
+			content, err := extfile.File2Base64(resultZip)
+			if err != nil {
+				return nil, new(extension_kit.ToError("Failed to open content file", err))
 			}
-			return &action_kit_api.StatusResult{
-				Completed: true,
-				Artifacts: new(artifacts),
-			}, nil
+			artifacts = append(artifacts, action_kit_api.Artifact{
+				Label: "$(experimentKey)_$(executionId)_" + state.ExecutionId.String() + "_steadybit-debug.tar.gz",
+				Data:  content,
+			})
+			log.Info().Msg("Uploading debug result: " + resultZip)
 		}
+		return &action_kit_api.StatusResult{
+			Completed: true,
+			Artifacts: new(artifacts),
+		}, nil
 	}
 	return &action_kit_api.StatusResult{
 		//indicate that the action is still running
@@ -189,25 +224,25 @@ func (l *debugAction) Status(_ context.Context, state *DebugActionState) (*actio
 func (l *debugAction) Stop(_ context.Context, state *DebugActionState) (*action_kit_api.StopResult, error) {
 	log.Info().Msg("Debug action **stop**")
 
-	run, _ := debugRuns.LoadAndDelete(state.ExecutionId)
-	finished := run != nil && run.(DebugRun).Finished
-
-	cancel, started := debugCancels.LoadAndDelete(state.ExecutionId)
-	if started {
-		// Signal the gather goroutine that its result is no longer wanted.
-		cancel.(context.CancelFunc)()
+	value, ok := debugRuns.LoadAndDelete(state.ExecutionId)
+	if !ok {
+		// Already stopped, or never prepared. Returning here also makes a duplicate Stop
+		// (e.g. a platform retry) a no-op, so it cannot remove WorkingDir while a still
+		// in-flight gather goroutine is tarring it.
+		return nil, nil
 	}
+	run := value.(*debugRun)
 
-	// WorkingDir holds the result archive. Remove it only when no gather goroutine could
-	// be tarring it — either none ran (e.g. prepared then rolled back), or it has already
-	// finished. While a gather is in flight, leave WorkingDir to the goroutine: removing
-	// it under an in-flight tar would make steadybit-debug os.Exit(1) and crash the whole
-	// extension.
-	if !started || finished {
-		if err := os.RemoveAll(state.WorkingDir); err != nil {
-			log.Err(err).Msg("Failed to remove temp dir")
-			return nil, err
-		}
+	run.mu.Lock()
+	defer run.mu.Unlock()
+	run.stopped = true
+	// Remove WorkingDir (which holds the result archive) only when no gather goroutine
+	// could still be tarring it: either none was started, or it has already finished.
+	// While a gather is in flight, leave WorkingDir to the goroutine, which removes it
+	// once RunSteadybitDebug returns and it observes stopped — removing it here under an
+	// in-flight tar would make steadybit-debug os.Exit(1) and crash the whole extension.
+	if !run.started || run.gatherDone {
+		run.removeWorkingDir()
 	}
 	return nil, nil
 }

--- a/extdebug/action.go
+++ b/extdebug/action.go
@@ -29,6 +29,9 @@ var (
 	_ action_kit_sdk.ActionWithStop[DebugActionState]   = (*debugAction)(nil) // Optional, needed when the action needs a stop method
 
 	debugRuns sync.Map
+	// debugCancels holds the cancel func for each running gather goroutine, keyed by
+	// execution id. Its presence also tells Stop whether a goroutine owns WorkingDir.
+	debugCancels sync.Map
 )
 
 type DebugRun struct {
@@ -113,6 +116,9 @@ func (l *debugAction) Prepare(_ context.Context, state *DebugActionState, reques
 func (l *debugAction) Start(_ context.Context, state *DebugActionState) (*action_kit_api.StartResult, error) {
 	log.Info().Msg("Debug action **start**")
 
+	ctx, cancel := context.WithCancel(context.Background())
+	debugCancels.Store(state.ExecutionId, cancel)
+
 	go func() {
 		// Recover so a panic while gathering debug information cannot crash the whole
 		// extension process (and take down other in-flight actions). Mark the run finished
@@ -124,6 +130,16 @@ func (l *debugAction) Start(_ context.Context, state *DebugActionState) (*action
 			}
 		}()
 		resultZip := RunSteadybitDebug(state.WorkingDir)
+
+		// If the action was stopped while gathering, the result archive (which lives
+		// inside WorkingDir) is no longer wanted, and Stop deliberately left WorkingDir
+		// for this goroutine to remove: Stop can't, because removing WorkingDir while the
+		// tar above was still running would make steadybit-debug os.Exit(1) and crash the
+		// whole extension. Now that the tar is done, it is safe to remove here.
+		if ctx.Err() != nil {
+			_ = os.RemoveAll(state.WorkingDir)
+			return
+		}
 		debugRuns.Store(state.ExecutionId, DebugRun{
 			Finished:  true,
 			ResultZip: resultZip,
@@ -173,12 +189,25 @@ func (l *debugAction) Status(_ context.Context, state *DebugActionState) (*actio
 func (l *debugAction) Stop(_ context.Context, state *DebugActionState) (*action_kit_api.StopResult, error) {
 	log.Info().Msg("Debug action **stop**")
 
-	debugRuns.Delete(state.ExecutionId)
+	run, _ := debugRuns.LoadAndDelete(state.ExecutionId)
+	finished := run != nil && run.(DebugRun).Finished
 
-	err := os.RemoveAll(state.WorkingDir)
-	if err != nil {
-		log.Err(err).Msg("Failed to remove temp dir")
-		return nil, err
+	cancel, started := debugCancels.LoadAndDelete(state.ExecutionId)
+	if started {
+		// Signal the gather goroutine that its result is no longer wanted.
+		cancel.(context.CancelFunc)()
+	}
+
+	// WorkingDir holds the result archive. Remove it only when no gather goroutine could
+	// be tarring it — either none ran (e.g. prepared then rolled back), or it has already
+	// finished. While a gather is in flight, leave WorkingDir to the goroutine: removing
+	// it under an in-flight tar would make steadybit-debug os.Exit(1) and crash the whole
+	// extension.
+	if !started || finished {
+		if err := os.RemoveAll(state.WorkingDir); err != nil {
+			log.Err(err).Msg("Failed to remove temp dir")
+			return nil, err
+		}
 	}
 	return nil, nil
 }

--- a/extdebug/action_test.go
+++ b/extdebug/action_test.go
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2024 steadybit GmbH. All rights reserved.
+ */
+
+package extdebug
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStopRemovesWorkingDirWhenGatherNeverStarted(t *testing.T) {
+	dir := t.TempDir()
+	state := &DebugActionState{ExecutionId: uuid.New(), WorkingDir: dir}
+
+	_, err := (&debugAction{}).Stop(context.Background(), state)
+	require.NoError(t, err)
+
+	_, statErr := os.Stat(dir)
+	assert.True(t, os.IsNotExist(statErr), "with no gather goroutine, Stop should remove WorkingDir")
+}
+
+func TestStopRemovesWorkingDirWhenGatherFinished(t *testing.T) {
+	dir := t.TempDir()
+	execId := uuid.New()
+	ctx, cancel := context.WithCancel(context.Background())
+	debugCancels.Store(execId, cancel)
+	debugRuns.Store(execId, DebugRun{Finished: true})
+
+	state := &DebugActionState{ExecutionId: execId, WorkingDir: dir}
+	_, err := (&debugAction{}).Stop(context.Background(), state)
+	require.NoError(t, err)
+
+	assert.Error(t, ctx.Err(), "the gather goroutine should be signalled")
+	_, statErr := os.Stat(dir)
+	assert.True(t, os.IsNotExist(statErr), "after the gather finished, Stop should remove WorkingDir (and the archive inside it)")
+	_, present := debugCancels.Load(execId)
+	assert.False(t, present, "Stop should drop the cancel entry")
+}
+
+func TestStopLeavesWorkingDirWhileGatherRunning(t *testing.T) {
+	dir := t.TempDir()
+	execId := uuid.New()
+	ctx, cancel := context.WithCancel(context.Background())
+	debugCancels.Store(execId, cancel)
+	debugRuns.Store(execId, DebugRun{Finished: false})
+
+	state := &DebugActionState{ExecutionId: execId, WorkingDir: dir}
+	_, err := (&debugAction{}).Stop(context.Background(), state)
+	require.NoError(t, err)
+
+	assert.Error(t, ctx.Err(), "the gather goroutine must be signalled to discard its result")
+	_, statErr := os.Stat(dir)
+	assert.NoError(t, statErr, "while a gather is in flight, Stop must leave WorkingDir — removing it under an in-flight tar would crash the process; the goroutine removes it on completion")
+	_, present := debugCancels.Load(execId)
+	assert.False(t, present, "Stop should drop the cancel entry")
+}

--- a/extdebug/action_test.go
+++ b/extdebug/action_test.go
@@ -14,49 +14,71 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func registerRun(t *testing.T, run *debugRun) (uuid.UUID, *DebugActionState) {
+	t.Helper()
+	id := uuid.New()
+	debugRuns.Store(id, run)
+	t.Cleanup(func() { debugRuns.Delete(id) })
+	return id, &DebugActionState{ExecutionId: id, WorkingDir: run.workingDir}
+}
+
+func assertRemoved(t *testing.T, dir string) {
+	t.Helper()
+	_, err := os.Stat(dir)
+	assert.True(t, os.IsNotExist(err), "WorkingDir should have been removed")
+}
+
 func TestStopRemovesWorkingDirWhenGatherNeverStarted(t *testing.T) {
 	dir := t.TempDir()
-	state := &DebugActionState{ExecutionId: uuid.New(), WorkingDir: dir}
+	_, state := registerRun(t, &debugRun{workingDir: dir})
 
 	_, err := (&debugAction{}).Stop(context.Background(), state)
 	require.NoError(t, err)
 
-	_, statErr := os.Stat(dir)
-	assert.True(t, os.IsNotExist(statErr), "with no gather goroutine, Stop should remove WorkingDir")
+	assertRemoved(t, dir)
 }
 
 func TestStopRemovesWorkingDirWhenGatherFinished(t *testing.T) {
 	dir := t.TempDir()
-	execId := uuid.New()
-	ctx, cancel := context.WithCancel(context.Background())
-	debugCancels.Store(execId, cancel)
-	debugRuns.Store(execId, DebugRun{Finished: true})
+	_, state := registerRun(t, &debugRun{workingDir: dir, started: true, gatherDone: true, finished: true})
 
-	state := &DebugActionState{ExecutionId: execId, WorkingDir: dir}
 	_, err := (&debugAction{}).Stop(context.Background(), state)
 	require.NoError(t, err)
 
-	assert.Error(t, ctx.Err(), "the gather goroutine should be signalled")
-	_, statErr := os.Stat(dir)
-	assert.True(t, os.IsNotExist(statErr), "after the gather finished, Stop should remove WorkingDir (and the archive inside it)")
-	_, present := debugCancels.Load(execId)
-	assert.False(t, present, "Stop should drop the cancel entry")
+	assertRemoved(t, dir)
 }
 
-func TestStopLeavesWorkingDirWhileGatherRunning(t *testing.T) {
+func TestStopLeavesWorkingDirWhileGatherInFlight(t *testing.T) {
 	dir := t.TempDir()
-	execId := uuid.New()
-	ctx, cancel := context.WithCancel(context.Background())
-	debugCancels.Store(execId, cancel)
-	debugRuns.Store(execId, DebugRun{Finished: false})
+	run := &debugRun{workingDir: dir, started: true}
+	_, state := registerRun(t, run)
 
-	state := &DebugActionState{ExecutionId: execId, WorkingDir: dir}
 	_, err := (&debugAction{}).Stop(context.Background(), state)
 	require.NoError(t, err)
 
-	assert.Error(t, ctx.Err(), "the gather goroutine must be signalled to discard its result")
 	_, statErr := os.Stat(dir)
-	assert.NoError(t, statErr, "while a gather is in flight, Stop must leave WorkingDir — removing it under an in-flight tar would crash the process; the goroutine removes it on completion")
-	_, present := debugCancels.Load(execId)
-	assert.False(t, present, "Stop should drop the cancel entry")
+	assert.NoError(t, statErr, "while a gather is in flight Stop must leave WorkingDir to the goroutine; removing it under an in-flight tar would crash the process")
+	run.mu.Lock()
+	assert.True(t, run.stopped, "the gather goroutine must be signalled to discard its result")
+	assert.False(t, run.cleaned, "Stop must not remove WorkingDir while the gather is in flight")
+	run.mu.Unlock()
+}
+
+func TestDuplicateStopDoesNotRemoveWorkingDirMidGather(t *testing.T) {
+	dir := t.TempDir()
+	run := &debugRun{workingDir: dir, started: true}
+	_, state := registerRun(t, run)
+
+	_, err := (&debugAction{}).Stop(context.Background(), state)
+	require.NoError(t, err)
+	// A retried Stop (the first already consumed the run) must be a no-op — it must not
+	// remove WorkingDir while the first call's gather goroutine may still be tarring it.
+	_, err = (&debugAction{}).Stop(context.Background(), state)
+	require.NoError(t, err)
+
+	_, statErr := os.Stat(dir)
+	assert.NoError(t, statErr, "duplicate Stop must not remove WorkingDir mid-gather")
+	run.mu.Lock()
+	assert.False(t, run.cleaned, "duplicate Stop must not remove WorkingDir mid-gather")
+	run.mu.Unlock()
 }


### PR DESCRIPTION
## Problem

The debug action gathers debug information in a background goroutine (`RunSteadybitDebug` → the in-process `steadybit-debug` library). `Stop` unconditionally did `os.RemoveAll(state.WorkingDir)`.

`steadybit-debug`'s `ZipOutputDirectory` runs `tar` over the working directory and calls **`os.Exit(1)` if the tar fails** (and `AddOutputDirectory` does the same on mkdir failure). So when an experiment is **stopped while the gather is still archiving**, `Stop` removing the working directory out from under the in-flight `tar` makes the library `os.Exit(1)` — **crashing the entire extension process** and taking down every other in-flight action. This is *not* caught by the existing panic recovery (#93), because `os.Exit` is not a panic.

`GatherInformation` takes no context, so the gather genuinely cannot be interrupted mid-run — the fix has to coordinate cleanup rather than cancel the work.

## Fix

- The result archive lives **inside** `WorkingDir` (`WorkingDir/steadybit-debug-<ts>.tar.gz`), so the gather goroutine must not remove `WorkingDir` before `Status` uploads the archive.
- `Stop` removes `WorkingDir` **only when no gather goroutine could be tarring it** — either none started (e.g. prepared then rolled back) or it has already finished. While a gather is in flight, `Stop` signals a per-run `context.CancelFunc` and leaves `WorkingDir` alone; the goroutine removes `WorkingDir` itself once its (uncancellable) work returns and it sees the cancel.

This removes the `os.RemoveAll`-during-`tar` crash window while keeping the working directory cleaned up in every path (normal completion, stop-mid-gather, and never-started).

Added unit tests for the three `Stop` paths.

## Deeper follow-up (out of scope)

The root cause is that `steadybit-debug`'s `AddOutputDirectory`/`ZipOutputDirectory` call `os.Exit(1)` on mkdir/tar failure, and `helper.go` calls those. The principled fix is to have `helper.go` do the mkdir + `tar` itself and return an error instead of `os.Exit`, which would remove the crash hazard at the source and let cleanup ownership be simpler. That reimplements library orchestration (and adds a `tar`-shelling surface), so it's left as a separate follow-up.

## Verification

`go build ./...`, `go vet ./...`, `go test -race ./extdebug/` all pass.
